### PR TITLE
drivers/mge-hid.c: refactor, treat ABM unknown as disabled

### DIFF
--- a/drivers/mge-hid.c
+++ b/drivers/mge-hid.c
@@ -235,9 +235,21 @@ static const char *eaton_abm_enabled_fun(double value)
 {
 	int abm_enabled_value = (int)value;
 
-	advanced_battery_monitoring = abm_enabled_value;
-
-	upsdebugx(2, "ABM overall status numeric value is %i", abm_enabled_value);
+	switch (abm_enabled_value)
+	{
+		case ABM_DISABLED:
+			advanced_battery_monitoring = ABM_DISABLED;
+			upsdebugx(2, "ABM status is: disabled (%i)", abm_enabled_value);
+			break;
+		case ABM_ENABLED:
+			advanced_battery_monitoring = ABM_ENABLED;
+			upsdebugx(2, "ABM status is: enabled (%i)", abm_enabled_value);
+			break;
+		default:
+			advanced_battery_monitoring = ABM_UNKNOWN;
+			upsdebugx(2, "ABM status is: unknown (%i)", abm_enabled_value);
+			break;
+	}
 
 	/* Return NULL, not to get the value published! */
 	return NULL;
@@ -257,10 +269,8 @@ static const char *eaton_abm_path_mode_fun(double value)
 	if (advanced_battery_path == ABM_PATH_UNKNOWN)
 	{
 		advanced_battery_path = ABM_PATH_MODE;
-		upsdebugx(2, "Set ABM path to: ABM_PATH_MODE (%i)", advanced_battery_path);
+		upsdebugx(2, "Set ABM path to: ABM_PATH_MODE (%i)", abm_path_mode_value);
 	}
-
-	upsdebugx(2, "ABM_PATH_MODE numeric value is: %i", abm_path_mode_value);
 
 	/* Return NULL, not to get the value published! */
 	return NULL;
@@ -280,10 +290,8 @@ static const char *eaton_abm_path_status_fun(double value)
 	if (advanced_battery_path == ABM_PATH_UNKNOWN)
 	{
 		advanced_battery_path = ABM_PATH_STATUS;
-		upsdebugx(2, "Set ABM path to: ABM_PATH_STATUS (%i)", advanced_battery_path);
+		upsdebugx(2, "Set ABM path to: ABM_PATH_STATUS (%i)", abm_path_status_value);
 	}
-
-	upsdebugx(2, "ABM_PATH_STATUS numeric value is: %i", abm_path_status_value);
 
 	/* Return NULL, not to get the value published! */
 	return NULL;
@@ -381,8 +389,7 @@ static const char *eaton_abm_status_fun(double value)
 		}
 	}
 
-	upsdebugx(2, "ABM charger numeric status is: %i", abm_status_value);
-	upsdebugx(2, "ABM charger string status: %s", mge_scratch_buf);
+	upsdebugx(2, "ABM charger status is: %s (%i)", mge_scratch_buf, abm_status_value);
 
 	return mge_scratch_buf;
 }
@@ -459,7 +466,7 @@ static const char *eaton_abm_chrg_dischrg_fun(double value)
 		}
 	}
 
-	upsdebugx(2, "ABM chrg/dischrg numeric value is: %i", abm_chrg_dischrg_value);
+	upsdebugx(2, "ABM charger flag is: %s (%i)", mge_scratch_buf, abm_chrg_dischrg_value);
 
 	return mge_scratch_buf;
 }

--- a/drivers/mge-hid.c
+++ b/drivers/mge-hid.c
@@ -238,7 +238,7 @@ static long round (LDOUBLE value)
 /* Used to store internally if ABM is enabled or not */
 static const char *eaton_abm_enabled_fun(double value)
 {
-	int abm_enabled_value = value;
+	int abm_enabled_value = (int)value;
 
 	advanced_battery_monitoring = abm_enabled_value;
 
@@ -256,7 +256,7 @@ static info_lkp_t eaton_abm_enabled_info[] = {
 /* ABM Path: UPS.BatterySystem.Charger.Mode (battery.charger.mode.status) */
 static const char *eaton_abm_path_mode_fun(double value)
 {
-	int abm_path_mode_value = value;
+	int abm_path_mode_value = (int)value;
 
 	/* If not yet initialized set ABM path to ABM_PATH_MODE */
 	if (advanced_battery_path == ABM_PATH_UNKNOWN)
@@ -279,7 +279,7 @@ static info_lkp_t eaton_abm_path_mode_info[] = {
 /* ABM Path: UPS.BatterySystem.Charger.Status (battery.charger.type.status) */
 static const char *eaton_abm_path_status_fun(double value)
 {
-	int abm_path_status_value = value;
+	int abm_path_status_value = (int)value;
 
 	/* If not yet initialized set ABM path to ABM_PATH_STATUS */
 	if (advanced_battery_path == ABM_PATH_UNKNOWN)
@@ -321,7 +321,7 @@ static info_lkp_t eaton_abm_enabled_legacy_info[] = {
 /* Used to process ABM status values (for battery.charger.status) */
 static const char *eaton_abm_status_fun(double value)
 {
-	int abm_status_value = value;
+	int abm_status_value = (int)value;
 
 	/* Don't process if ABM is unknown or disabled */
 	if (advanced_battery_monitoring == ABM_UNKNOWN || advanced_battery_monitoring == ABM_DISABLED) {
@@ -400,13 +400,13 @@ static info_lkp_t eaton_abm_status_info[] = {
 /* Used to process another type of enabled ABM (by battery.charger.type) */
 static const char *eaton_abm_charger_type_fun(double value)
 {
-	int abm_charger_type = value;
+	int abm_charger_type = (int)value;
 
 	if (abm_charger_type == ABM_ENABLED_TYPE)
 	{
 		/* Set ABM to enabled when encountering ABM-enabled battery.charger.type */
 		advanced_battery_monitoring = ABM_ENABLED_TYPE;
-		upsdebugx(2, "ABM charger type: %i", (int)value);
+		upsdebugx(2, "ABM charger type: %i", abm_charger_type);
 
 		return "ABM";
 	}
@@ -428,7 +428,7 @@ static info_lkp_t eaton_charger_type_info[] = {
 /* Used to process ABM status flags, for ups.status (CHRG/DISCHRG/RB) */
 static const char *eaton_abm_chrg_dischrg_fun(double value)
 {
-	int abm_chrg_dischrg_value = value;
+	int abm_chrg_dischrg_value = (int)value;
 
 	/* Don't process if ABM is unknown or disabled */
 	if (advanced_battery_monitoring == ABM_UNKNOWN || advanced_battery_monitoring == ABM_DISABLED)

--- a/drivers/mge-hid.c
+++ b/drivers/mge-hid.c
@@ -265,8 +265,8 @@ static const char *eaton_abm_path_mode_fun(double value)
 {
 	int abm_path_mode_value = (int)value;
 
-	/* If not yet initialized set ABM path to ABM_PATH_MODE */
-	if (advanced_battery_path == ABM_PATH_UNKNOWN)
+	/* If ABM_ENABLED and not yet initialized set ABM path to ABM_PATH_MODE */
+	if (advanced_battery_monitoring == ABM_ENABLED && advanced_battery_path == ABM_PATH_UNKNOWN)
 	{
 		advanced_battery_path = ABM_PATH_MODE;
 		upsdebugx(2, "Set ABM path to: ABM_PATH_MODE (%i)", abm_path_mode_value);
@@ -286,8 +286,8 @@ static const char *eaton_abm_path_status_fun(double value)
 {
 	int abm_path_status_value = (int)value;
 
-	/* If not yet initialized set ABM path to ABM_PATH_STATUS */
-	if (advanced_battery_path == ABM_PATH_UNKNOWN)
+	/* If ABM_ENABLED and not yet initialized set ABM path to ABM_PATH_STATUS */
+	if (advanced_battery_monitoring == ABM_ENABLED && advanced_battery_path == ABM_PATH_UNKNOWN)
 	{
 		advanced_battery_path = ABM_PATH_STATUS;
 		upsdebugx(2, "Set ABM path to: ABM_PATH_STATUS (%i)", abm_path_status_value);
@@ -321,7 +321,7 @@ static info_lkp_t eaton_abm_enabled_legacy_info[] = {
 };
 #endif /* if 0 */
 
-/* Used to process ABM status values (for battery.charger.status) */
+/* Used to process ABM status text (for battery.charger.status) */
 static const char *eaton_abm_status_fun(double value)
 {
 	int abm_status_value = (int)value;
@@ -335,7 +335,7 @@ static const char *eaton_abm_status_fun(double value)
 	}
 
 	/* ABM Path: UPS.BatterySystem.Charger.Status (battery.charger.type.status)
-	 * as seen with 9 series devices (and possibly others): */
+	 * as more recent and seen with 9 series devices (and possibly others): */
 	if (advanced_battery_path == ABM_PATH_STATUS)
 	{
 		switch (abm_status_value)
@@ -409,7 +409,7 @@ static info_lkp_t eaton_charger_type_info[] = {
 	{ 0, NULL, NULL, NULL }
 };
 
-/* Used to process ABM status flags, for ups.status (CHRG/DISCHRG/RB) */
+/* Used to process ABM status flags, for ups.status (CHRG/DISCHRG) */
 static const char *eaton_abm_chrg_dischrg_fun(double value)
 {
 	int abm_chrg_dischrg_value = (int)value;
@@ -419,7 +419,7 @@ static const char *eaton_abm_chrg_dischrg_fun(double value)
 		return NULL;
 
 	/* ABM Path: UPS.BatterySystem.Charger.Status (battery.charger.type.status)
-	 * as seen with 9 series devices (and possibly others): */
+	 * as more recent and seen with 9 series devices (and possibly others): */
 	if (advanced_battery_path == ABM_PATH_STATUS)
 	{
 		switch (abm_chrg_dischrg_value)
@@ -428,7 +428,6 @@ static const char *eaton_abm_chrg_dischrg_fun(double value)
 				snprintf(mge_scratch_buf, sizeof(mge_scratch_buf), "%s", "chrg");
 				break;
 			case 2: /* floating status */
-				/* charging status, floating status */
 				snprintf(mge_scratch_buf, sizeof(mge_scratch_buf), "%s", "chrg");
 				break;
 			case 4: /* discharging status */
@@ -454,7 +453,7 @@ static const char *eaton_abm_chrg_dischrg_fun(double value)
 			case 3: /* floating status */
 				snprintf(mge_scratch_buf, sizeof(mge_scratch_buf), "%s", "chrg");
 				break;
-			case 2:
+			case 2: /* discharging status */
 				snprintf(mge_scratch_buf, sizeof(mge_scratch_buf), "%s", "dischrg");
 				break;
 			case 6: /* ABM Charger Disabled */


### PR DESCRIPTION
I tried to illustrate here my code review/comments on the PR: https://github.com/networkupstools/nut/pull/2660

1. We've seen non-ABM capable devices with partial ABM paths, these were previously sent into ABM parsing functions. Treating `ABM_UNKNOWN` as `ABM_DISABLED` resolves this problem, ABM parsing functions should only be executed if ABM is explicitly `ABM_ENABLED`. This also allows for graceful transition from `ABM_UNKNOWN`/`ABM_DISABLED` to `ABM_ENABLED`.

2. Removed `ABM_ENABLED_TYPE` as an additional way of enabling ABM, this is just a textual value for the battery charger type and ABM disabled/enabled is already handled through the correct HID path (x.ABMEnable) in another function. An ABM battery charger type can still be ABM disabled, so it makes no sense to assume enable ABM based on the charger type.

3. Improved the two ABM decision paths (old + new) with clear structure, comments, improved function and variable names.

4. Improved the checking of ABM enabled-ness by checking for known values, rather than assigning any values directly.

5. Improved debug messages to be more clear and condensed, as they seemed to be partially overlapping in some areas.

6. Improved multiple implicitly casted variables to explicit casting in a single place where it felt correct to do so.